### PR TITLE
Fix config name bug

### DIFF
--- a/src/SparkInvite.php
+++ b/src/SparkInvite.php
@@ -43,12 +43,12 @@ class SparkInvite
 
     public function acceptLink($invitation)
     {
-        return secure_url(str_replace('{token}', $invitation->token, config('sparkinvites.routes.accept')));
+        return secure_url(str_replace('{token}', $invitation->token, config('sparkinvite.routes.accept')));
     }
 
     public function rejectLink($invitation)
     {
-        return secure_url(str_replace('{token}', $invitation->token, config('sparkinvites.routes.reject')));
+        return secure_url(str_replace('{token}', $invitation->token, config('sparkinvite.routes.reject')));
     }
 
     /**


### PR DESCRIPTION
I assume this is a bug, at least the system doesn't work for me this way, my config file is named `sparkinvite` and not `sparkinviteS` as in the code. This fixes the bug where `SparkInvite@acceptLink` and `SparkInvite@rejectLink` does not work.

Or am I missing something here..?